### PR TITLE
Add workflow for building / publishing packages from mono-repos to support angular libraries

### DIFF
--- a/.github/workflows/build-and-publish-angular-libraries.yml
+++ b/.github/workflows/build-and-publish-angular-libraries.yml
@@ -67,10 +67,11 @@ jobs:
           # Defaults to the user or organization that owns the workflow file
           scope: '@cuvmit'
 
+        # Once verdaccio is removed this needs to be added before npm publish: 
+        # npm version --no-git-tag-version --allow-same-version --workspaces-update=false --workspace=$(dirname ${pkg}) ${VERSION}
       - run: |
           for pkg in $(find dist -name package.json); do
             VERSION=$(jq --raw-output ".version" ${pkg})${{ env.VERSION_SUFFIX }}
-            npm version --no-git-tag-version --allow-same-version --workspaces-update=false --workspace=$(dirname ${pkg}) ${VERSION}
             npm publish $(dirname ${pkg}) --tag ${{ env.PACKAGE_TAG }} 
           done
         env:

--- a/.github/workflows/build-and-publish-angular-libraries.yml
+++ b/.github/workflows/build-and-publish-angular-libraries.yml
@@ -1,0 +1,77 @@
+name: build-and-publish-angular-libraries
+on:
+  workflow_call:
+    inputs:
+      webtier:
+        required: true
+        type: string
+      node_version:
+        required: true
+        type: string
+    secrets:
+      verdaccio_token:
+        required: true
+
+jobs:
+  build-and-publish-angular-libaries:
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.webtier }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # This is temporary until Verdaccio is gone.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node_version }}
+          registry-url: 'https://verdaccio.vmit.cucloud.net'
+          always-auth: true
+
+      - name: Cache node modules
+        uses: actions/cache@v4
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: ./node_modules
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+
+      - name: build
+        run: yarn build:${{ inputs.webtier }}
+
+      - name: set main version suffix for sb
+        run: |
+          echo VERSION_SUFFIX=-beta.${{ github.run_number }} >> $GITHUB_ENV
+          echo PACKAGE_TAG=beta >> $GITHUB_ENV
+        if: ${{ inputs.webtier == 'sb'}}
+
+      - name: set main version suffix for prod
+        run: |
+          echo VERSION_SUFFIX= >> $GITHUB_ENV
+          echo PACKAGE_TAG=latest >> $GITHUB_ENV
+        if: ${{ inputs.webtier == 'prod'}}
+
+      - name: Publish Package to Verdaccio
+        run: |
+          for pkg in $(find dist -name package.json); do
+            VERSION=$(jq --raw-output ".version" $pkg)${{ env.VERSION_SUFFIX }}
+            yarn publish $(dirname ${pkg}) --no-git-tag-version --tag ${{ env.PACKAGE_TAG }} --new-version ${VERSION}
+          done
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node_version }}
+          registry-url: 'https://npm.pkg.github.com'
+          # Defaults to the user or organization that owns the workflow file
+          scope: '@cuvmit'
+
+      - run: |
+          for pkg in $(find dist -name package.json); do
+            VERSION=$(jq --raw-output ".version" ${pkg})${{ env.VERSION_SUFFIX }}
+            npm version --no-git-tag-version --allow-same-version --workspaces-update=false --workspace=$(dirname ${pkg}) ${VERSION}
+            npm publish $(dirname ${pkg}) --tag ${{ env.PACKAGE_TAG }} 
+          done
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-and-publish-angular-libraries.yml
+++ b/.github/workflows/build-and-publish-angular-libraries.yml
@@ -36,26 +36,30 @@ jobs:
           path: ./node_modules
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
 
-      - name: build
-        run: yarn build:${{ inputs.webtier }}
-
       - name: set main version suffix for sb
         run: |
-          echo VERSION_SUFFIX=-beta.${{ github.run_number }} >> $GITHUB_ENV
+          echo VERSION_PREID=beta.${{ github.run_number }} >> $GITHUB_ENV
+          echo VERSION_MODIFIER=prerelease >> $GITHUB_ENV
           echo PACKAGE_TAG=beta >> $GITHUB_ENV
         if: ${{ inputs.webtier == 'sb'}}
 
       - name: set main version suffix for prod
         run: |
-          echo VERSION_SUFFIX= >> $GITHUB_ENV
+          echo VERSION_PREID=rc >> $GITHUB_ENV
+          echo VERSION_MODIFIER=patch >> $GITHUB_ENV
           echo PACKAGE_TAG=latest >> $GITHUB_ENV
         if: ${{ inputs.webtier == 'prod'}}
+
+      - name: set package versions
+        run: yarn exec:${{ inputs.webtier }} -- npm version --no-git-tag-version --no-workspaces-update --preid=${{ env.VERSION_PREID }} ${{ env.VERSION_MODIFIER }}
+
+      - name: build
+        run: yarn build:${{ inputs.webtier }}
 
       - name: Publish Package to Verdaccio
         run: |
           for pkg in $(find dist -name package.json); do
-            VERSION=$(jq --raw-output ".version" $pkg)${{ env.VERSION_SUFFIX }}
-            yarn publish $(dirname ${pkg}) --no-git-tag-version --tag ${{ env.PACKAGE_TAG }} --new-version ${VERSION}
+            npm publish $(dirname ${pkg}) --tag ${{ env.PACKAGE_TAG }}
           done
         env:
           NODE_AUTH_TOKEN: ${{ secrets.VERDACCIO_TOKEN }}
@@ -67,11 +71,9 @@ jobs:
           # Defaults to the user or organization that owns the workflow file
           scope: '@cuvmit'
 
-        # Once verdaccio is removed this needs to be added before npm publish: 
-        # npm version --no-git-tag-version --allow-same-version --workspaces-update=false --workspace=$(dirname ${pkg}) ${VERSION}
-      - run: |
+      - name: Publish Package to Github Registry
+        run: |
           for pkg in $(find dist -name package.json); do
-            VERSION=$(jq --raw-output ".version" ${pkg})${{ env.VERSION_SUFFIX }}
             npm publish $(dirname ${pkg}) --tag ${{ env.PACKAGE_TAG }} 
           done
         env:

--- a/.github/workflows/build-and-publish-angular-libraries.yml
+++ b/.github/workflows/build-and-publish-angular-libraries.yml
@@ -36,11 +36,12 @@ jobs:
           path: ./node_modules
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
 
-      - name: set main version suffix for sb
+      - name: set main version suffix for sb and fetch main refs
         run: |
           echo VERSION_PREID=beta.${{ github.run_number }} >> $GITHUB_ENV
           echo VERSION_MODIFIER=prerelease >> $GITHUB_ENV
           echo PACKAGE_TAG=beta >> $GITHUB_ENV
+          git fetch origin main
         if: ${{ inputs.webtier == 'sb'}}
 
       - name: set main version suffix for prod

--- a/.github/workflows/build-and-publish-angular-libraries.yml
+++ b/.github/workflows/build-and-publish-angular-libraries.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
 
       # This is temporary until Verdaccio is gone.
       - uses: actions/setup-node@v4


### PR DESCRIPTION
I believe this new workflow is adequate for the purpose of supporting repos that produce angular libraries using the default structure setup by the angular-cli. The only additions required were some npm scripts (exec:<webtier>, build:<webtier>) that can execute the requested actions for the packages that are updated. I used [lerna](https://lerna.js.org/docs/introduction) to automate this process.

I tested both sb and prod initially with an update to all packages: [sb](https://github.com/cuvmit/ngx-cuvmit/actions/runs/14979830984/job/42081046097), [prod](https://github.com/cuvmit/ngx-cuvmit/actions/runs/14980334866/job/42082696379) 
and then with a pull request that only updated one of the packages: [sb](https://github.com/cuvmit/ngx-cuvmit/actions/runs/14980611187/job/42083605911), [prod](https://github.com/cuvmit/ngx-cuvmit/actions/runs/14980654984/job/42083745299)

