### PR TITLE
Ignore secondary entrypoints when publishing packages

### DIFF
--- a/.github/workflows/build-and-publish-angular-libraries.yml
+++ b/.github/workflows/build-and-publish-angular-libraries.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Publish Package to Verdaccio
         run: |
-          for pkg in $(find dist -name package.json -depth 3); do
+          for pkg in $(find dist -name package.json -maxdepth 3); do
             npm publish $(dirname ${pkg}) --tag ${{ env.PACKAGE_TAG }}
           done
         env:
@@ -76,7 +76,7 @@ jobs:
 
       - name: Publish Package to Github Registry
         run: |
-          for pkg in $(find dist -name package.json -depth 3); do
+          for pkg in $(find dist -name package.json -maxdepth 3); do
             npm publish $(dirname ${pkg}) --tag ${{ env.PACKAGE_TAG }} 
           done
         env:

--- a/.github/workflows/build-and-publish-angular-libraries.yml
+++ b/.github/workflows/build-and-publish-angular-libraries.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Publish Package to Verdaccio
         run: |
-          for pkg in $(find dist -name package.json); do
+          for pkg in $(find dist -name package.json -depth 3); do
             npm publish $(dirname ${pkg}) --tag ${{ env.PACKAGE_TAG }}
           done
         env:
@@ -76,7 +76,7 @@ jobs:
 
       - name: Publish Package to Github Registry
         run: |
-          for pkg in $(find dist -name package.json); do
+          for pkg in $(find dist -name package.json -depth 3); do
             npm publish $(dirname ${pkg}) --tag ${{ env.PACKAGE_TAG }} 
           done
         env:


### PR DESCRIPTION
I encountered this issue when I added a secondary entrypoint to @cuvmit/ngx-vetview.

> Sidebar: secondary entrypoints help break up the library code so you can do better tree shaking and in this case so I could add an optional peer dependency that is only needed if you use code from the secondary entrypoint (e.g. `import {} from '@cuvmit/ngx-vetview/<secondary>'`

When building libraries with secondary entrypoints, additional package.json files are generated in the secondary folders. Therefore, I limited the search for libraries to publish to a max depth of 3 which should return only those at the top level of the build.

I tested this on ngx-cuvmit and it appears to work as desired.