### PR TITLE
Support multiple deployments

### DIFF
--- a/.github/workflows/build-and-deploy-nodejs-multi-github-packages.yml
+++ b/.github/workflows/build-and-deploy-nodejs-multi-github-packages.yml
@@ -1,0 +1,166 @@
+name: build-and-deploy-nodejs-multi-github-packages
+on:
+  workflow_call:
+    inputs:
+      webtier:
+        required: true
+        type: string
+      node_version:
+        required: true
+        type: string
+      working_directory:
+        required: false
+        default: '.'
+        type: string
+      additional_deployments:
+        required: false
+        type: string
+        default: ''
+    secrets:
+      aws_access_key_id:
+        required: true
+      aws_secret_access_key:
+        required: true
+      k8s_token:
+        required: true
+      k8s_ca:
+        required: true
+      k8s_api_host:
+        required: true
+      sentry_auth_token:
+        required: false
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  build-and-deploy-nodejs-api-github-packages:
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.webtier }}
+    env:
+      AWS_REGISTRY_URL: 165158508528.dkr.ecr.us-east-1.amazonaws.com
+    defaults:
+      run:
+        working-directory: ${{ inputs.working_directory }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # These environment vars are specific to sb
+      - name: set package version
+        run:
+          echo PACKAGE_VERSION=$(jq --raw-output ".version" package.json) >>
+          $GITHUB_ENV
+
+      - name: Get Prod Version
+        run: echo PROD_VERSION=$(aws ecr describe-images --repository-name ${{ github.event.repository.name }} | jq --raw-output '.imageDetails[] | .imageTags | select(.[1]) | select(.[0] == "prod" or .[1] == "prod") | if .[1] == "prod" then .[0] else .[1] end') >> $GITHUB_ENV
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: 'us-east-1'
+
+      - name: Print versions
+        run: echo Package Version is ${{ env.PACKAGE_VERSION }} and production Version is ${{ env.PROD_VERSION }}
+
+      - name: Exit if equal
+        if: ${{ env.PACKAGE_VERSION == env.PROD_VERSION }}
+        run: |
+          echo 'CTRL-Z!  You forgot to bump your version number, comrade!  Edit the version number in package.json and commit to re-run.'
+          this_command_doesnt_exist_so_exit
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ inputs.node_version }}
+          cache: 'yarn'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: build
+        run: yarn build:${{ inputs.webtier }}
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: set main version for sb
+        run: echo VERSION=${{ env.PACKAGE_VERSION }}-beta.${{ github.run_number }} >> $GITHUB_ENV
+        if: ${{ inputs.webtier == 'sb'}}
+
+      - name: set main version for prod
+        run: echo VERSION=${{ env.PACKAGE_VERSION }} >> $GITHUB_ENV
+        if: ${{ inputs.webtier == 'prod'}}
+
+      - name: set Docker image tag
+        run: echo IMAGE_TAG=${{ env.AWS_REGISTRY_URL }}/${{ github.event.repository.name }}:${{ env.VERSION }} >> $GITHUB_ENV
+
+      - name: set Tier Pointer tag
+        run: echo TIER_POINTER_TAG=${{ env.AWS_REGISTRY_URL }}/${{ github.event.repository.name }}:${{ inputs.webtier }} >> $GITHUB_ENV
+
+      - name: set K8S Name
+        run: echo K8S_NAME=$(echo ${{github.event.repository.name }} | tr _ -) >> $GITHUB_ENV
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.aws_access_key_id }}
+          aws-secret-access-key: ${{ secrets.aws_secret_access_key }}
+          aws-region: us-east-1
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Create repo if doesn't exist (ECR)
+        uses: int128/create-ecr-repository-action@v1
+        with:
+          repository: ${{ github.event.repository.name }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          build-args: |
+            webtier=${{ inputs.webtier }}
+            aws_access_key_id=${{ secrets.aws_access_key_id }}
+            aws_secret_access_key=${{ secrets.aws_secret_access_key }}
+          context: ${{ inputs.working_directory }}
+          push: true
+          tags: |
+            ${{ env.IMAGE_TAG }}
+            ${{ env.TIER_POINTER_TAG }}
+
+      - uses: azure/setup-kubectl@v4.0.0
+
+      - name: Deploy to Kubernetes
+        run: |
+          echo ${{ secrets.k8s_token }} | base64 -d > ./k8s_token
+          echo ${{ secrets.k8s_ca }} | base64 -d > ./k8s_ca
+          kubectl config set-cluster arn:aws:eks:us-east-1:165158508528:cluster/eks-${{ inputs.webtier }} --server=https://${{ secrets.k8s_api_host }} --certificate-authority=./k8s_ca
+          kubectl config set-credentials github-actions --token="$(cat ./k8s_token)"
+          kubectl config set-context deployer --cluster=arn:aws:eks:us-east-1:165158508528:cluster/eks-${{ inputs.webtier }} --user=github-actions
+          kubectl config use-context deployer
+
+          # Create the K8s deployment, service and ingress if it doesn't exist.  Initially this will point to
+          # the repo's :sb or :prod tag, which was created in the publish step.  Then we'll point it to the
+          # exact version tag.
+          RESPONSE=$(kubectl get deployment/${{ env.K8S_NAME }}-${{ inputs.webtier }}-deployment --ignore-not-found)
+          if [ -z $RESPONSE ]
+          then
+            kubectl create --save-config -f config/k8s/${{ env.K8S_NAME }}-${{ inputs.webtier }}.yaml
+          else
+            kubectl apply -f config/k8s/${{ env.K8S_NAME }}-${{ inputs.webtier }}.yaml
+          fi
+
+          kubectl set image deployment/${{ env.K8S_NAME }}-${{ inputs.webtier }}-deployment ${{ env.K8S_NAME }}-${{ inputs.webtier }}=${{ env.IMAGE_TAG }}
+          OTHER_DEPLOYMENTS="${{ inputs.additional_deployments }}"
+          if [ -n "$OTHER_DEPLOYMENTS" ]
+          then
+            IFS=',' read -r -a array <<< "$OTHER_DEPLOYMENTS"
+
+            for deployment in "${array[@]}"; do
+              kubectl set image deployment/${deployment}-${{ inputs.webtier }}-deployment ${deployment}-${{ inputs.webtier }}=${{ env.IMAGE_TAG }}
+            done
+          fi

--- a/.github/workflows/build-and-deploy-nodejs-multi.yml
+++ b/.github/workflows/build-and-deploy-nodejs-multi.yml
@@ -1,0 +1,164 @@
+name: build-and-deploy-nodejs-multi
+on:
+  workflow_call:
+    inputs:
+      webtier:
+        required: true
+        type: string
+      node_version:
+        required: true
+        type: string
+      working_directory:
+        required: false
+        default: '.'
+        type: string
+      additional_deployments:
+        required: false
+        type: string
+        default: ''
+    secrets:
+      aws_access_key_id:
+        required: true
+      aws_secret_access_key:
+        required: true
+      k8s_token:
+        required: true
+      k8s_ca:
+        required: true
+      k8s_api_host:
+        required: true
+      sentry_auth_token:
+        required: false
+
+jobs:
+  build-and-deploy-nodejs-multi:
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.webtier }}
+    env:
+      AWS_REGISTRY_URL: 165158508528.dkr.ecr.us-east-1.amazonaws.com
+    defaults:
+      run:
+        working-directory: ${{ inputs.working_directory }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # These environment vars are specific to sb
+      - name: set package version
+        run: echo PACKAGE_VERSION=$(jq --raw-output ".version" package.json) >> $GITHUB_ENV
+
+      - name: Get Prod Version
+        run: echo PROD_VERSION=$(aws ecr describe-images --repository-name ${{ github.event.repository.name }} | jq --raw-output '.imageDetails[] | .imageTags | select(.[1]) | select(.[0] == "prod" or .[1] == "prod") | if .[1] == "prod" then .[0] else .[1] end') >> $GITHUB_ENV
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: 'us-east-1'
+
+      - name: Print versions
+        run: echo Package Version is ${{ env.PACKAGE_VERSION }} and production Version is ${{ env.PROD_VERSION }}
+
+      - name: Exit if equal
+        if: ${{ env.PACKAGE_VERSION == env.PROD_VERSION }}
+        run: |
+          echo 'CTRL-Z!  You forgot to bump your version number, comrade!  Edit the version number in package.json and commit to re-run.'
+          this_command_doesnt_exist_so_exit
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node_version }}
+
+      - name: Cache node modules
+        uses: actions/cache@v4
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: ./node_modules
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+
+      - name: build
+        run: yarn build:${{ inputs.webtier }}
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+
+      - name: set main version for sb
+        run: echo VERSION=${{ env.PACKAGE_VERSION }}-beta.${{ github.run_number }} >> $GITHUB_ENV
+        if: ${{ inputs.webtier == 'sb'}}
+
+      - name: set main version for prod
+        run: echo VERSION=${{ env.PACKAGE_VERSION }} >> $GITHUB_ENV
+        if: ${{ inputs.webtier == 'prod'}}
+
+      - name: set Docker image tag
+        run: echo IMAGE_TAG=${{ env.AWS_REGISTRY_URL }}/${{ github.event.repository.name }}:${{ env.VERSION }} >> $GITHUB_ENV
+
+      - name: set Tier Pointer tag
+        run: echo TIER_POINTER_TAG=${{ env.AWS_REGISTRY_URL }}/${{ github.event.repository.name }}:${{ inputs.webtier }} >> $GITHUB_ENV
+
+      - name: set K8S Name
+        run: echo K8S_NAME=$(echo ${{github.event.repository.name }} | tr _ -) >> $GITHUB_ENV
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.aws_access_key_id }}
+          aws-secret-access-key: ${{ secrets.aws_secret_access_key }}
+          aws-region: us-east-1
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Create repo if doesn't exist (ECR)
+        uses: int128/create-ecr-repository-action@v1
+        with:
+          repository: ${{ github.event.repository.name }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          build-args: |
+            webtier=${{ inputs.webtier }}
+            aws_access_key_id=${{ secrets.aws_access_key_id }}
+            aws_secret_access_key=${{ secrets.aws_secret_access_key }}
+          context: ${{ inputs.working_directory }}
+          push: true
+          tags: |
+            ${{ env.IMAGE_TAG }}
+            ${{ env.TIER_POINTER_TAG }}
+
+      - uses: azure/setup-kubectl@v4.0.0
+
+      - name: Deploy to Kubernetes
+        run: |
+          echo ${{ secrets.k8s_token }} | base64 -d > ./k8s_token
+          echo ${{ secrets.k8s_ca }} | base64 -d > ./k8s_ca
+          kubectl config set-cluster arn:aws:eks:us-east-1:165158508528:cluster/eks-${{ inputs.webtier }} --server=https://${{ secrets.k8s_api_host }} --certificate-authority=./k8s_ca
+          kubectl config set-credentials github-actions --token="$(cat ./k8s_token)"
+          kubectl config set-context deployer --cluster=arn:aws:eks:us-east-1:165158508528:cluster/eks-${{ inputs.webtier }} --user=github-actions
+          kubectl config use-context deployer
+
+          # Create the K8s deployment, service and ingress if it doesn't exist.  Initially this will point to
+          # the repo's :sb or :prod tag, which was created in the publish step.  Then we'll point it to the
+          # exact version tag.
+          RESPONSE=$(kubectl get deployment/${{ env.K8S_NAME }}-${{ inputs.webtier }}-deployment --ignore-not-found)
+          if [ -z $RESPONSE ]
+          then
+            kubectl create --save-config -f config/k8s/${{ env.K8S_NAME }}-${{ inputs.webtier }}.yaml
+          else
+            kubectl apply -f config/k8s/${{ env.K8S_NAME }}-${{ inputs.webtier }}.yaml
+          fi
+
+          kubectl set image deployment/${{ env.K8S_NAME }}-${{ inputs.webtier }}-deployment ${{ env.K8S_NAME }}-${{ inputs.webtier }}=${{ env.IMAGE_TAG }}
+          OTHER_DEPLOYMENTS="${{ inputs.additional_deployments }}"
+          if [ -n $OTHER_DEPLOYMENTS ]
+          then
+            IFS=',' read -r -a array <<< "$OTHER_DEPLOYMENTS"
+
+            for deployment in "${array[@]}"; do
+              kubectl set image deployment/${deployment}-${{ inputs.webtier }}-deployment ${deployment}-${{ inputs.webtier }}=${{ env.IMAGE_TAG }}
+            done
+          fi

--- a/.github/workflows/build-and-deploy-nodejs-multi.yml
+++ b/.github/workflows/build-and-deploy-nodejs-multi.yml
@@ -145,7 +145,7 @@ jobs:
           # the repo's :sb or :prod tag, which was created in the publish step.  Then we'll point it to the
           # exact version tag.
           RESPONSE=$(kubectl get deployment/${{ env.K8S_NAME }}-${{ inputs.webtier }}-deployment --ignore-not-found)
-          if [ -z $RESPONSE ]
+          if [ -z "$RESPONSE" ]
           then
             kubectl create --save-config -f config/k8s/${{ env.K8S_NAME }}-${{ inputs.webtier }}.yaml
           else
@@ -154,7 +154,7 @@ jobs:
 
           kubectl set image deployment/${{ env.K8S_NAME }}-${{ inputs.webtier }}-deployment ${{ env.K8S_NAME }}-${{ inputs.webtier }}=${{ env.IMAGE_TAG }}
           OTHER_DEPLOYMENTS="${{ inputs.additional_deployments }}"
-          if [ -n $OTHER_DEPLOYMENTS ]
+          if [ -n "$OTHER_DEPLOYMENTS" ]
           then
             IFS=',' read -r -a array <<< "$OTHER_DEPLOYMENTS"
 


### PR DESCRIPTION
So, I ended up not bothering with additional .yaml files for the k8s deployments since they can all be in the same yaml file and just added an input parameter where you could specify additional deployments to update. I guess this could just be a mod to the existing workflow instead of a new one, but I figured it's best to kick the tires on this for a bit until we decide it is good to merge into one or more of the other ones.

The only changes from build-and-deploy-nodejs-api.yml are the `additional_deployments` input and everything on line 156 and later.