### PR TITLE
DEVOPS-230 Split off Github Package Scripts

### DIFF
--- a/.github/workflows/build-and-deploy-angular-client-github-packages.yml
+++ b/.github/workflows/build-and-deploy-angular-client-github-packages.yml
@@ -40,8 +40,6 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: ${{ inputs.node_version }}
-        with:
-          node-version: ${{ inputs.node_version }}
           cache: 'yarn'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-and-deploy-angular-client-github-packages.yml
+++ b/.github/workflows/build-and-deploy-angular-client-github-packages.yml
@@ -1,0 +1,146 @@
+name: build-and-deploy-angular-client-github-packages
+on:
+  workflow_call:
+    inputs:
+      webtier:
+        required: true
+        type: string
+      node_version:
+        required: true
+        type: string
+      web_server:
+        required: true
+        type: string
+      legacy:
+        default: false
+        required: false
+        type: boolean
+    secrets:
+      aws_access_key_id:
+        required: true
+      aws_secret_access_key:
+        required: true
+      sentry_auth_token:
+        required: false
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  build-and-deploy-angular-client-github-packages:
+    runs-on: ubuntu-latest
+    # This is the environment the package is deplyed to, and has nothing to do with env variables
+    environment: ${{ inputs.webtier }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ inputs.node_version }}
+        with:
+          node-version: ${{ inputs.node_version }}
+          cache: 'yarn'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: build
+        run: yarn build:${{ inputs.webtier }}
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # These are built and uploaded to Sentry in the build step. We don't want
+      # them published to prod.
+      - name: Delete source maps
+        run: rm -rf dist/**/*.map
+
+      - name: set S3 target for app-sb
+        run: |
+          echo S3_BUCKET=app-sb.vet.cornell.edu >> $GITHUB_ENV
+          echo S3_SYNC_HOST=app-sb.vet.cornell.edu >> $GITHUB_ENV
+        if: ${{ inputs.webtier == 'sb' && inputs.web_server == 'app' }}
+
+      - name: set S3 target for app
+        run: |
+          echo S3_BUCKET=app.vet.cornell.edu >> $GITHUB_ENV
+          echo S3_SYNC_HOST=app.vet.cornell.edu >> $GITHUB_ENV
+        if: ${{ inputs.webtier == 'prod' && inputs.web_server == 'app' }}
+
+      - name: set S3 target for vetapp-sb or vetapp
+        run: |
+          echo S3_BUCKET=vetapp-${{ inputs.webtier }}.vmit.cucloud.net >> $GITHUB_ENV
+          echo S3_SYNC_HOST=vetapp-${{ inputs.webtier }}-lb.vmit.cucloud.net >> $GITHUB_ENV
+        if: ${{ inputs.web_server == 'vetapp' }}
+
+      # Default is esbuild = false
+      - name: set esbuild flag default
+        run: echo USES_ESBUILD=0 >> $GITHUB_ENV
+
+      # Set esbuild flag if there's a directory named dist/REPO/browser
+      - name: set esbuild flag if dist browser dir exists
+        if: ${{ hashFiles('dist/**/browser') != '' }}
+        run: echo USES_ESBUILD=1 >> $GITHUB_ENV
+
+      - name:
+          Determine root of compiled code - Angular Apps with esbuild (after
+          v17)
+        run:
+          echo COMPILED_ROOT=dist/${{ github.event.repository.name }}/browser >>
+          $GITHUB_ENV
+        if: ${{ ! inputs.legacy && env.USES_ESBUILD == '1' }}
+
+      - name:
+          Determine root of compiled code - Angular Apps without esbuild (before
+          v17)
+        run:
+          echo COMPILED_ROOT=dist/${{ github.event.repository.name }} >>
+          $GITHUB_ENV
+        if: ${{ ! inputs.legacy && env.USES_ESBUILD == '0' }}
+
+      - name: Determine root of compiled code - Legacy AngularJS Apps
+        run: echo COMPILED_ROOT=dist >> $GITHUB_ENV
+        if: ${{ inputs.legacy }}
+
+      - name: Synchronize compiled code to S3 - Angular apps
+        run:
+          aws s3 sync --delete ${{ env.COMPILED_ROOT }} s3://${{ env.S3_BUCKET
+          }}/${{ github.event.repository.name }}
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: 'us-east-1'
+
+      # We used to use haythem/public-ip@v1.3 but the underlying public IP service it used was unreliable.
+      # So this is the technique from https://github.com/haythem/public-ip/issues/23
+      - name: Get Public IP
+        id: publicip
+        run: |
+          response=$(curl -s canhazip.com)
+          echo "ip='$response'" >> "$GITHUB_OUTPUT"
+
+      - name:
+          Vetapp only - add Github Actions IP to Security group cloud-ci-tools
+        run: |
+          aws ec2 authorize-security-group-ingress --group-id sg-06a1c0133c41d79b9 --protocol tcp --port 443 --cidr ${{ steps.publicip.outputs.ip }}/32
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: 'us-east-1'
+        if: ${{ inputs.web_server == 'vetapp' }}
+
+      - name: Trigger sync from S3 to web_server
+        run: curl -k https://${{ env.S3_SYNC_HOST }}/cgi-bin/s3sync
+
+      - name:
+          Vetapp only - remove Github Actions IP from Security group
+          cloud-ci-tools
+        run: |
+          aws ec2 revoke-security-group-ingress --group-id sg-06a1c0133c41d79b9 --protocol tcp --port 443 --cidr ${{ steps.publicip.outputs.ip }}/32
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: 'us-east-1'
+        if: ${{ inputs.web_server == 'vetapp' }}

--- a/.github/workflows/build-and-deploy-angular-workspace-github-packages.yml
+++ b/.github/workflows/build-and-deploy-angular-workspace-github-packages.yml
@@ -1,0 +1,133 @@
+# Note: this is a stop-gap measure.  It's almost identical to build-and-deploy-angular-client
+# except for the S3 copy step, which requires multiple directories.  A better way to do this would
+# be to read the project information and loop over it, but I don't have time to do that right now.
+
+name: build-and-deploy-angular-workspace-github-packages
+on:
+  workflow_call:
+    inputs:
+      webtier:
+        required: true
+        type: string
+      node_version:
+        required: true
+        type: string
+      web_server:
+        required: true
+        type: string
+      project1:
+        required: true
+        type: string
+      project2:
+        required: true
+        type: string
+    secrets:
+      aws_access_key_id:
+        required: true
+      aws_secret_access_key:
+        required: true
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  build-and-deploy-angular-workspace-github-packages:
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.webtier }}
+    env:
+      AWS_REGISTRY_URL: 165158508528.dkr.ecr.us-east-1.amazonaws.com
+      K8S_CLUSTER: k8s.vmit.cucloud.net
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ inputs.node_version }}
+          cache: 'yarn'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: build
+        run: yarn build:${{ inputs.webtier }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: set S3 target for app-sb
+        run: |
+          echo S3_BUCKET=app-sb.vet.cornell.edu >> $GITHUB_ENV
+          echo S3_SYNC_HOST=app-sb.vet.cornell.edu >> $GITHUB_ENV
+        if: ${{ inputs.webtier == 'sb' && inputs.web_server == 'app' }}
+
+      - name: set S3 target for app
+        run: |
+          echo S3_BUCKET=app.vet.cornell.edu >> $GITHUB_ENV
+          echo S3_SYNC_HOST=app.vet.cornell.edu >> $GITHUB_ENV
+        if: ${{ inputs.webtier == 'prod' && inputs.web_server == 'app' }}
+
+      - name: set S3 target for vetapp-sb or vetapp
+        run: |
+          echo S3_BUCKET=vetapp-${{ inputs.webtier }}.vmit.cucloud.net >> $GITHUB_ENV
+          echo S3_SYNC_HOST=vetapp-${{ inputs.webtier }}-lb.vmit.cucloud.net >> $GITHUB_ENV
+        if: ${{ inputs.web_server == 'vetapp' }}
+
+      # The next two steps should be a loop of some sort
+      - name: Determine root of compiled code - Angular Apps
+        run:
+          echo COMPILED_ROOT=dist/${{ inputs.project1 }}/browser >> $GITHUB_ENV
+
+      - name: Synchronize compiled code to S3 - Angular apps
+        run:
+          aws s3 sync --delete ${{ env.COMPILED_ROOT }} s3://${{ env.S3_BUCKET
+          }}/${{ inputs.project1 }}
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: 'us-east-1'
+
+      - name: Determine root of compiled code - Angular Apps
+        run:
+          echo COMPILED_ROOT=dist/${{ inputs.project2 }}/browser >> $GITHUB_ENV
+
+      - name: Synchronize compiled code to S3 - Angular apps
+        run:
+          aws s3 sync --delete ${{ env.COMPILED_ROOT }} s3://${{ env.S3_BUCKET
+          }}/${{ inputs.project2 }}
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: 'us-east-1'
+
+      # We used to use haythem/public-ip@v1.3 but the underlying public IP service it used was unreliable.
+      # So this is the technique from https://github.com/haythem/public-ip/issues/23
+      - name: Get Public IP
+        id: publicip
+        run: |
+          response=$(curl -s canhazip.com)
+          echo "ip='$response'" >> "$GITHUB_OUTPUT"
+
+      - name:
+          Vetapp only - add Github Actions IP to Security group cloud-ci-tools
+        run: |
+          aws ec2 authorize-security-group-ingress --group-id sg-06a1c0133c41d79b9 --protocol tcp --port 443 --cidr ${{ steps.publicip.outputs.ip }}/32
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: 'us-east-1'
+        if: ${{ inputs.web_server == 'vetapp' }}
+
+      - name: Trigger sync from S3 to web_server
+        run: curl -k https://${{ env.S3_SYNC_HOST }}/cgi-bin/s3sync
+
+      - name:
+          Vetapp only - remove Github Actions IP from Security group
+          cloud-ci-tools
+        run: |
+          aws ec2 revoke-security-group-ingress --group-id sg-06a1c0133c41d79b9 --protocol tcp --port 443 --cidr ${{ steps.publicip.outputs.ip }}/32
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: 'us-east-1'
+        if: ${{ inputs.web_server == 'vetapp' }}

--- a/.github/workflows/build-and-deploy-nodejs-api-github-packages.yml
+++ b/.github/workflows/build-and-deploy-nodejs-api-github-packages.yml
@@ -79,35 +79,21 @@ jobs:
         with:
           node-version: ${{ inputs.node_version }}
 
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
+
       - name: Restore cache node modules
         uses: actions/cache/restore@v5
-        env:
-          cache-name: cache-node-modules
         with:
-          path: ./node_modules
-          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}-build
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
 
       - name: build
         run: yarn build:${{ inputs.webtier }}
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Save cache node modules
-        uses: actions/cache/save@v5
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: ./node_modules
-          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}-build
-
-      - name: Restore cache node modules for docker
-        uses: actions/cache/restore@v5
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: ./node_modules
-          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}-docker
 
       - name: build-for-docker
         run: yarn build-for-docker:${{ inputs.webtier }}
@@ -117,11 +103,9 @@ jobs:
 
       - name: Save cache node modules for docker
         uses: actions/cache/save@v5
-        env:
-          cache-name: cache-node-modules
         with:
-          path: ./node_modules
-          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}-docker
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
 
       - name: set main version for sb
         run:

--- a/.github/workflows/build-and-deploy-nodejs-api-github-packages.yml
+++ b/.github/workflows/build-and-deploy-nodejs-api-github-packages.yml
@@ -82,6 +82,9 @@ jobs:
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
+        # This is needed because yarn cache dir fails if you don't pass it.
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Restore cache node modules
         uses: actions/cache/restore@v5

--- a/.github/workflows/build-and-deploy-nodejs-api-github-packages.yml
+++ b/.github/workflows/build-and-deploy-nodejs-api-github-packages.yml
@@ -1,6 +1,3 @@
-# This is temporarily split out until we can verify Github Packages works.  When it does,
-# we can merge it back into build-and-deploy-general-api and use different setup depending
-# on whether .npmrc is present
 name: build-and-deploy-nodejs-api-github-packages
 on:
   workflow_call:
@@ -34,7 +31,7 @@ permissions:
   packages: read
 
 jobs:
-  build-and-deploy-nodejs-api:
+  build-and-deploy-nodejs-api-github-packages:
     runs-on: ubuntu-latest
     environment: ${{ inputs.webtier }}
     env:
@@ -75,43 +72,18 @@ jobs:
           echo 'CTRL-Z!  You forgot to bump your version number, comrade!  Edit the version number in package.json and commit to re-run.'
           this_command_doesnt_exist_so_exit
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ inputs.node_version }}
           cache: 'yarn'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # - name: Get yarn cache directory path
-      #   id: yarn-cache-dir-path
-      #   run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
-      #   # This is needed because yarn cache dir fails if you don't pass it.
-      #   env:
-      #     NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      # - name: Restore cache node modules
-      #   uses: actions/cache/restore@v5
-      #   with:
-      #     path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-      #     key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-
       - name: build
         run: yarn build:${{ inputs.webtier }}
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: build-for-docker
-        run: yarn build-for-docker:${{ inputs.webtier }}
-        env:
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      # - name: Save cache node modules for docker
-      #   uses: actions/cache/save@v5
-      #   with:
-      #     path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-      #     key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
 
       - name: set main version for sb
         run:

--- a/.github/workflows/build-and-deploy-nodejs-api-github-packages.yml
+++ b/.github/workflows/build-and-deploy-nodejs-api-github-packages.yml
@@ -28,9 +28,10 @@ on:
         required: true
       sentry_auth_token:
         required: false
-    permissions:
-      contents: read
-      packages: read
+
+permissions:
+  contents: read
+  packages: read
 
 jobs:
   build-and-deploy-nodejs-api:

--- a/.github/workflows/build-and-deploy-nodejs-api-github-packages.yml
+++ b/.github/workflows/build-and-deploy-nodejs-api-github-packages.yml
@@ -79,6 +79,8 @@ jobs:
         with:
           node-version: ${{ inputs.node_version }}
           cache: 'yarn'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # - name: Get yarn cache directory path
       #   id: yarn-cache-dir-path

--- a/.github/workflows/build-and-deploy-nodejs-api-github-packages.yml
+++ b/.github/workflows/build-and-deploy-nodejs-api-github-packages.yml
@@ -78,19 +78,20 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ inputs.node_version }}
+          cache: 'yarn'
 
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
-        # This is needed because yarn cache dir fails if you don't pass it.
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # - name: Get yarn cache directory path
+      #   id: yarn-cache-dir-path
+      #   run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
+      #   # This is needed because yarn cache dir fails if you don't pass it.
+      #   env:
+      #     NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Restore cache node modules
-        uses: actions/cache/restore@v5
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+      # - name: Restore cache node modules
+      #   uses: actions/cache/restore@v5
+      #   with:
+      #     path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+      #     key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
 
       - name: build
         run: yarn build:${{ inputs.webtier }}
@@ -104,11 +105,11 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Save cache node modules for docker
-        uses: actions/cache/save@v5
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+      # - name: Save cache node modules for docker
+      #   uses: actions/cache/save@v5
+      #   with:
+      #     path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+      #     key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
 
       - name: set main version for sb
         run:

--- a/.github/workflows/build-and-deploy-nodejs-api-github-packages.yml
+++ b/.github/workflows/build-and-deploy-nodejs-api-github-packages.yml
@@ -1,0 +1,174 @@
+# This is temporarily split out until we can verify Github Packages works.  When it does,
+# we can merge it back into build-and-deploy-general-api and use different setup depending
+# on whether .npmrc is present
+name: build-and-deploy-nodejs-api-github-packages
+on:
+  workflow_call:
+    inputs:
+      webtier:
+        required: true
+        type: string
+      node_version:
+        required: true
+        type: string
+      working_directory:
+        required: false
+        default: '.'
+        type: string
+    secrets:
+      aws_access_key_id:
+        required: true
+      aws_secret_access_key:
+        required: true
+      k8s_token:
+        required: true
+      k8s_ca:
+        required: true
+      k8s_api_host:
+        required: true
+      sentry_auth_token:
+        required: false
+    permissions:
+      contents: read
+      packages: read
+
+jobs:
+  build-and-deploy-nodejs-api:
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.webtier }}
+    env:
+      AWS_REGISTRY_URL: 165158508528.dkr.ecr.us-east-1.amazonaws.com
+    defaults:
+      run:
+        working-directory: ${{ inputs.working_directory }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # These environment vars are specific to sb
+      - name: set package version
+        run:
+          echo PACKAGE_VERSION=$(jq --raw-output ".version" package.json) >>
+          $GITHUB_ENV
+
+      - name: Get Prod Version
+        run:
+          echo PROD_VERSION=$(aws ecr describe-images --repository-name ${{
+          github.event.repository.name }} | jq --raw-output '.imageDetails[] |
+          .imageTags | select(.[1]) | select(.[0] == "prod" or .[1] == "prod") |
+          if .[1] == "prod" then .[0] else .[1] end') >> $GITHUB_ENV
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: 'us-east-1'
+
+      - name: Print versions
+        run:
+          echo Package Version is ${{ env.PACKAGE_VERSION }} and production
+          Version is ${{ env.PROD_VERSION }}
+
+      - name: Exit if equal
+        if: ${{ env.PACKAGE_VERSION == env.PROD_VERSION }}
+        run: |
+          echo 'CTRL-Z!  You forgot to bump your version number, comrade!  Edit the version number in package.json and commit to re-run.'
+          this_command_doesnt_exist_so_exit
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node_version }}
+
+      - name: Cache node modules
+        uses: actions/cache@v4
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: ./node_modules
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+
+      - name: build
+        run: yarn build:${{ inputs.webtier }}
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: set main version for sb
+        run:
+          echo VERSION=${{ env.PACKAGE_VERSION }}-beta.${{ github.run_number }}
+          >> $GITHUB_ENV
+        if: ${{ inputs.webtier == 'sb'}}
+
+      - name: set main version for prod
+        run: echo VERSION=${{ env.PACKAGE_VERSION }} >> $GITHUB_ENV
+        if: ${{ inputs.webtier == 'prod'}}
+
+      - name: set Docker image tag
+        run:
+          echo IMAGE_TAG=${{ env.AWS_REGISTRY_URL }}/${{
+          github.event.repository.name }}:${{ env.VERSION }} >> $GITHUB_ENV
+
+      - name: set Tier Pointer tag
+        run:
+          echo TIER_POINTER_TAG=${{ env.AWS_REGISTRY_URL }}/${{
+          github.event.repository.name }}:${{ inputs.webtier }} >> $GITHUB_ENV
+
+      - name: set K8S Name
+        run:
+          echo K8S_NAME=$(echo ${{github.event.repository.name }} | tr _ -) >>
+          $GITHUB_ENV
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.aws_access_key_id }}
+          aws-secret-access-key: ${{ secrets.aws_secret_access_key }}
+          aws-region: us-east-1
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Create repo if doesn't exist (ECR)
+        uses: int128/create-ecr-repository-action@v1
+        with:
+          repository: ${{ github.event.repository.name }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          build-args: |
+            webtier=${{ inputs.webtier }}
+            aws_access_key_id=${{ secrets.aws_access_key_id }}
+            aws_secret_access_key=${{ secrets.aws_secret_access_key }}
+          context: ${{ inputs.working_directory }}
+          push: true
+          tags: |
+            ${{ env.IMAGE_TAG }}
+            ${{ env.TIER_POINTER_TAG }}
+
+      - uses: azure/setup-kubectl@v4.0.0
+
+      - name: Deploy to Kubernetes
+        run: |
+          echo ${{ secrets.k8s_token }} | base64 -d > ./k8s_token
+          echo ${{ secrets.k8s_ca }} | base64 -d > ./k8s_ca
+          kubectl config set-cluster arn:aws:eks:us-east-1:165158508528:cluster/eks-${{ inputs.webtier }} --server=https://${{ secrets.k8s_api_host }} --certificate-authority=./k8s_ca
+          kubectl config set-credentials github-actions --token="$(cat ./k8s_token)"
+          kubectl config set-context deployer --cluster=arn:aws:eks:us-east-1:165158508528:cluster/eks-${{ inputs.webtier }} --user=github-actions
+          kubectl config use-context deployer
+
+          # Create the K8s deployment, service and ingress if it doesn't exist.  Initially this will point to
+          # the repo's :sb or :prod tag, which was created in the publish step.  Then we'll point it to the
+          # exact version tag.
+          RESPONSE=$(kubectl get deployment/${{ env.K8S_NAME }}-${{ inputs.webtier }}-deployment --ignore-not-found)
+          if [ -z $RESPONSE ]
+          then
+            kubectl create --save-config -f config/k8s/${{ env.K8S_NAME }}-${{ inputs.webtier }}.yaml
+          else
+            kubectl apply -f config/k8s/${{ env.K8S_NAME }}-${{ inputs.webtier }}.yaml
+          fi
+
+          kubectl set image deployment/${{ env.K8S_NAME }}-${{ inputs.webtier }}-deployment ${{ env.K8S_NAME }}-${{ inputs.webtier }}=${{ env.IMAGE_TAG }}

--- a/.github/workflows/build-and-deploy-nodejs-api-github-packages.yml
+++ b/.github/workflows/build-and-deploy-nodejs-api-github-packages.yml
@@ -79,19 +79,49 @@ jobs:
         with:
           node-version: ${{ inputs.node_version }}
 
-      - name: Cache node modules
-        uses: actions/cache@v4
+      - name: Restore cache node modules
+        uses: actions/cache/restore@v5
         env:
           cache-name: cache-node-modules
         with:
           path: ./node_modules
-          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}-build
 
       - name: build
         run: yarn build:${{ inputs.webtier }}
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Save cache node modules
+        uses: actions/cache/save@v5
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: ./node_modules
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}-build
+
+      - name: Restore cache node modules for docker
+        uses: actions/cache/restore@v5
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: ./node_modules
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}-docker
+
+      - name: build-for-docker
+        run: yarn build-for-docker:${{ inputs.webtier }}
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Save cache node modules for docker
+        uses: actions/cache/save@v5
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: ./node_modules
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}-docker
 
       - name: set main version for sb
         run:

--- a/.github/workflows/build-and-deploy-nodejs-batch-github-packages.yml
+++ b/.github/workflows/build-and-deploy-nodejs-batch-github-packages.yml
@@ -1,0 +1,135 @@
+name: build-and-deploy-nodejs-batch
+on:
+  workflow_call:
+    inputs:
+      webtier:
+        required: true
+        type: string
+      node_version:
+        required: true
+        type: string
+      working_directory:
+        required: false
+        default: '.'
+        type: string
+    secrets:
+      aws_access_key_id:
+        required: true
+      aws_secret_access_key:
+        required: true
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  build-and-deploy-nodejs-batch:
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.webtier }}
+    env:
+      AWS_REGISTRY_URL: 165158508528.dkr.ecr.us-east-1.amazonaws.com
+      K8S_CLUSTER: k8s.vmit.cucloud.net
+    defaults:
+      run:
+        working-directory: ${{ inputs.working_directory }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # These environment vars are specific to sb
+      - name: set package version
+        run:
+          echo PACKAGE_VERSION=$(jq --raw-output ".version" package.json) >>
+          $GITHUB_ENV
+
+      - name: Get Prod Version
+        run:
+          echo PROD_VERSION=$(aws ecr describe-images --repository-name ${{
+          github.event.repository.name }} | jq --raw-output '.imageDetails[] |
+          .imageTags | select(.[1]) | select(.[0] == "prod" or .[1] == "prod") |
+          if .[1] == "prod" then .[0] else .[1] end') >> $GITHUB_ENV
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: 'us-east-1'
+
+      - name: Print versions
+        run:
+          echo Package Version is ${{ env.PACKAGE_VERSION }} and production
+          Version is ${{ env.PROD_VERSION }}
+
+      - name: Exit if equal
+        if: ${{ env.PACKAGE_VERSION == env.PROD_VERSION }}
+        run: |
+          echo 'CTRL-Z!  You forgot to bump your version number, comrade!  Edit the version number in package.json and commit to re-run.'
+          this_command_doesnt_exist_so_exit
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ inputs.node_version }}
+          cache: 'yarn'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: build
+        run: yarn build:${{ inputs.webtier }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: set main version for sb
+        run:
+          echo VERSION=${{ env.PACKAGE_VERSION }}-beta.${{ github.run_number }}
+          >> $GITHUB_ENV
+        if: ${{ inputs.webtier == 'sb'}}
+
+      - name: set main version for prod
+        run: echo VERSION=${{ env.PACKAGE_VERSION }} >> $GITHUB_ENV
+        if: ${{ inputs.webtier == 'prod'}}
+
+      - name: set Docker image tag
+        run:
+          echo IMAGE_TAG=${{ env.AWS_REGISTRY_URL }}/${{
+          github.event.repository.name }}:${{ env.VERSION }} >> $GITHUB_ENV
+
+      - name: set Tier Pointer tag
+        run:
+          echo TIER_POINTER_TAG=${{ env.AWS_REGISTRY_URL }}/${{
+          github.event.repository.name }}:${{ inputs.webtier }} >> $GITHUB_ENV
+
+      - name: set K8S Name
+        run:
+          echo K8S_NAME=$(echo ${{github.event.repository.name }} | tr _ -) >>
+          $GITHUB_ENV
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.aws_access_key_id }}
+          aws-secret-access-key: ${{ secrets.aws_secret_access_key }}
+          aws-region: us-east-1
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Create repo if doesn't exist (ECR)
+        uses: int128/create-ecr-repository-action@v1
+        with:
+          repository: ${{ github.event.repository.name }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          build-args: |
+            webtier=${{ inputs.webtier }}
+            aws_access_key_id=${{ secrets.aws_access_key_id }}
+            aws_secret_access_key=${{ secrets.aws_secret_access_key }}
+          context: ${{ inputs.working_directory }}
+          push: true
+          tags: |
+            ${{ env.IMAGE_TAG }}
+            ${{ env.TIER_POINTER_TAG }}


### PR DESCRIPTION
These are parallel scripts that converted repos can use when moving from Verdaccio to Github Packages.  The only substantive changes:

- Gives Actions script explicit permissions to access Github Packages
- Passes GITHUB_TOKEN, which is a service token that has all rights to read/write that the repo has.  Because all of our @cuvmit-scoped Github Pacvkages have visibilitiy "internal", a private repo's Github Token can be used to access it via Yarn or NPM.
- Changes caching to the default, which is to save the global cache in .yarn/cache rather than the node_modules directories.  They are pretty much equivalent, except in Education API's where I get all dev+prod dependencies, do a build, then pare it down to just the Production dependencies for the Docker image.  This step change greatly speeds up those builds.  

Once Verdaccio is gone, we can get rid of the original scripts and these will become the definitive ones.  (And should be baked into Schematics at that time).  