### PR TITLE
rename action to be non-angular specific

### DIFF
--- a/.github/workflows/build-and-publish-libraries.yml
+++ b/.github/workflows/build-and-publish-libraries.yml
@@ -1,4 +1,4 @@
-name: build-and-publish-angular-libraries
+name: build-and-publish-libraries
 on:
   workflow_call:
     inputs:
@@ -10,7 +10,7 @@ on:
         type: string
 
 jobs:
-  build-and-publish-angular-libaries:
+  build-and-publish-libaries:
     runs-on: ubuntu-latest
     environment: ${{ inputs.webtier }}
 


### PR DESCRIPTION
This action is currently only used by ngx-cuvmit, but it turns out there's nothing angular specific about this action. I'm setting up a new project for nestjs libraries and decided to rename this action to avoid confusion about its use.